### PR TITLE
Speed up auto sweet

### DIFF
--- a/fc_main.js
+++ b/fc_main.js
@@ -2517,12 +2517,7 @@ function autoSweetAction() {
 
         if (!autoSweetAction.state && !Game.OnAscend && !Game.AscendTimer) {
             logEvent("autoSweet", 'No "Sweet" detected, ascending');
-            Game.ClosePrompt();
-            Game.Ascend(1);
-            setTimeout(function () {
-                Game.ClosePrompt();
-                Game.Reincarnate(1);
-            }, 10000);
+            Game.Reincarnate(1);
         }
 
         switch (autoSweetAction.state) {


### PR DESCRIPTION
## Changes
- Call `Game.Reincarnate(1)` immediately to skip ascending animation and ascension tree

Fixes #163 