### PR TITLE
Update Harvest Bank logic

### DIFF
--- a/fc_main.js
+++ b/fc_main.js
@@ -1574,7 +1574,11 @@ function bestBank(minEfficiency) {
         FrozenCookies.autoCasting == 5 || FrozenCookies.holdSEBank
             ? edificeBank()
             : 0;
-    var bankLevels = [0, luckyBank(), luckyFrenzyBank(), harvestBank()]
+    var harvest = 
+        FrozenCookies.setHarvestBankPlant
+            ? harvestBank()
+            : 0;
+    var bankLevels = [0, luckyBank(), luckyFrenzyBank()]
         .sort(function (a, b) {
             return b - a;
         })
@@ -1585,15 +1589,14 @@ function bestBank(minEfficiency) {
             };
         })
         .filter(function (bank) {
-            return (bank.efficiency >= 0 && bank.efficiency <= minEfficiency) ||
-                FrozenCookies.setHarvestBankPlant
+            return (bank.efficiency >= 0 && bank.efficiency <= minEfficiency)
                 ? bank
                 : null;
         });
-    if (bankLevels[0].cost > edifice || FrozenCookies.setHarvestBankPlant)
+    if (bankLevels[0].cost > edifice && bankLevels[0].cost > harvest)
         return bankLevels[0];
     return {
-        cost: edifice,
+        cost: Math.max(edifice, harvest),
         efficiency: 1,
     };
 }


### PR DESCRIPTION
change harvest bank logic so it works as expected, only using the calculated amount, rather than original logic that forces all banks as valid selections if harvest bank is enabled

without harvest during frenzy, harvest bank is often lower than lucky+frenzy bank, but forced the selection of the higher lucky+frenzy amount due to the original logic

new logic is effectively a copy of SE bank logic, and does not interfere with GC bank efficiency logic