### PR TITLE
Unify Base CPS calculation & fix Wrinkler logic

### DIFF
--- a/fc_main.js
+++ b/fc_main.js
@@ -1064,7 +1064,7 @@ function baseClickingCps(clickSpeed) {
 
 function effectiveCps(delay, wrathValue, wrinklerCount) {
     wrathValue = wrathValue != null ? wrathValue : Game.elderWrath;
-    wrinklerCount = wrinklerCount != null ? wrinklerCount : wrathValue ? 10 : 0;
+    wrinklerCount = wrinklerCount != null ? wrinklerCount : (wrathValue ? (10 + 2 * (Game.Has("Elder Spice") + Game.hasAura("Dragon Guts"))) : 0);
     var wrinkler = wrinklerMod(wrinklerCount);
     if (delay == null) delay = delayAmount();
     return (
@@ -2752,7 +2752,7 @@ function shouldPopWrinklers() {
             var nextRecCps = nextPurchase().delta_cps;
             var wrinklersNeeded = wrinklerList
                 .sort(function (w1, w2) {
-                    return w1.sucked < w2.sucked;
+                    return w2.sucked - w1.sucked;
                 })
                 .reduce(
                     function (current, w) {

--- a/fc_main.js
+++ b/fc_main.js
@@ -1047,11 +1047,8 @@ function hasClickBuff() {
 }
 
 function baseCps() {
-    var buffMod = 1;
-    for (var i in Game.buffs) {
-        if (typeof Game.buffs[i].multCpS != "undefined")
-            buffMod *= Game.buffs[i].multCpS;
-    }
+    var buffMod = cpsBonus();
+
     if (buffMod === 0) return FrozenCookies.lastBaseCPS;
     var baseCPS = Game.cookiesPs / buffMod;
     FrozenCookies.lastBaseCPS = baseCPS;
@@ -1060,7 +1057,7 @@ function baseCps() {
 
 function baseClickingCps(clickSpeed) {
     var clickFrenzyMod = clickBuffBonus();
-    var frenzyMod = Game.hasBuff("Frenzy") ? Game.buffs["Frenzy"].multCpS : 1;
+    var frenzyMod = cpsBonus(); //Game.hasBuff("Frenzy") ? Game.buffs["Frenzy"].multCpS : 1;
     var cpc = Game.mouseCps() / (clickFrenzyMod * frenzyMod);
     return clickSpeed * cpc;
 }

--- a/fc_main.js
+++ b/fc_main.js
@@ -1064,7 +1064,7 @@ function baseClickingCps(clickSpeed) {
 
 function effectiveCps(delay, wrathValue, wrinklerCount) {
     wrathValue = wrathValue != null ? wrathValue : Game.elderWrath;
-    wrinklerCount = wrinklerCount != null ? wrinklerCount : (wrathValue ? (10 + 2 * (Game.Has("Elder Spice") + Game.hasAura("Dragon Guts"))) : 0);
+    wrinklerCount = wrinklerCount != null ? wrinklerCount : (wrathValue ? (10 + 2 * (Game.Has("Elder spice") + Game.hasAura("Dragon Guts"))) : 0);
     var wrinkler = wrinklerMod(wrinklerCount);
     if (delay == null) delay = delayAmount();
     return (


### PR DESCRIPTION
Call `cpsBonus()` function rather than have duplicate of its code in `baseCps()`

take into account all buffs when calculating base click CPS, not just frenzy

implement wrinkler sorting function properly (`A < B` is not a valid sorting function, use `B - A` to sort in descending order)

improve Effective CPS accuracy by using actual max wrinkler count