### PR TITLE
Minigame check fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -745,7 +745,6 @@ been changed. Existing settings should transfer 1:1.
 
 -   **Lag:** Frozen Cookies can cause noticeable lag due to its complexity. Lower the auto-click speed if performance drops.
 -   **Golden Cookie timers:** Occasionally, Golden Cookie timers may disappear from the infobox. They will reappear with the next Golden Cookie spawn.
--   **Autocasting:** If Frozen Cookies loads before Wizard Towers are unlocked, autocasting may not activate automatically, even after unlocking them. Reload the game and mod to enable autocasting. This may also affect other minigame features like banks.
 
 For more issues or feature requests, see the [GitHub issues page](https://github.com/erbkaiser/FrozenCookies/issues). Contributions and suggestions are welcome!
 

--- a/fc_main.js
+++ b/fc_main.js
@@ -755,6 +755,14 @@ var B = Game.Objects["Bank"].minigame; //Stock Market
 var T = Game.Objects["Temple"].minigame; //Pantheon
 var M = Game.Objects["Wizard tower"].minigame; //Grimoire
 
+function minigameCheckAction() {
+    if (!G) G = Game.Objects["Farm"].minigame; //Garden
+    if (!B) B = Game.Objects["Bank"].minigame; //Stock Market
+    if (!T) T = Game.Objects["Temple"].minigame; //Pantheon
+    if (!M) M = Game.Objects["Wizard tower"].minigame; //Grimoire
+    if (G && B && T && M) clearInterval(FrozenCookies.autoMinigameCheckBot);
+}
+
 function autoTicker() {
     if (Game.TickerEffect && Game.TickerEffect.type == "fortune")
         Game.tickerL.click();
@@ -3473,6 +3481,11 @@ function FCStart() {
         FrozenCookies.recommendedSettingsBot = 0;
     }
 
+    if (FrozenCookies.autoMinigameCheckBot) {
+        clearInterval(FrozenCookies.autoMinigameCheckBot);
+        FrozenCookies.autoMinigameCheckBot = 0;
+    }
+
     // Now create new intervals with their specified frequencies.
     // Default frequency is 100ms = 1/10th of a second
 
@@ -3663,6 +3676,12 @@ function FCStart() {
             recommendedSettingsAction,
             FrozenCookies.frequency
         );
+    }
+
+    if (!G || !B || !T || !M) {
+        FrozenCookies.autoMinigameCheckBot = setInterval(
+            minigameCheckAction,
+            FrozenCookies.frequency * 600 // 1 minute
     }
 
     if (statSpeed(FrozenCookies.trackStats) > 0) {

--- a/fc_main.js
+++ b/fc_main.js
@@ -3682,6 +3682,7 @@ function FCStart() {
         FrozenCookies.autoMinigameCheckBot = setInterval(
             minigameCheckAction,
             FrozenCookies.frequency * 600 // 1 minute
+        );
     }
 
     if (statSpeed(FrozenCookies.trackStats) > 0) {


### PR DESCRIPTION
add code to re-check minigame availability every 60s for any minigames that were previously unavailable, eliminating the need to reload the game to activate features related to newly unlocked minigames

closes #154 and related

(feel free to tweak the checking rate if you wish)