### PR TITLE
Century Egg hitching fix

### DIFF
--- a/fc_main.js
+++ b/fc_main.js
@@ -282,7 +282,7 @@ function setOverrides(gameSaveData) {
     eval(
         "FrozenCookies.safeGainsCalc = " +
             Game.CalculateGains.toString()
-                .replace(/eggMult\+=\(1.+/, "eggMult++; // CENTURY EGGS SUCK")
+                .replace(/Game\.Has\('Century egg'\)/, "false) // CENTURY EGGS SUCK")
                 .replace(/Game\.cookiesPs/g, "FrozenCookies.calculatedCps")
                 .replace(/Game\.globalCpsMult/g, "mult")
     );


### PR DESCRIPTION
fixes a small hitch that occurs ever 10s or so if Century Egg is unlocked

(updated an old fix so that it works again)